### PR TITLE
Update Examples to work with GxEPD 3.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ By default your Badgy displays the welcome message when powered on. To upload ne
 3. The screen should now update letting you know to connect to the "Badgy AP" network. You can now let go of the center button
 4. Using your mobile phone, connect to the "Badgy AP" WiFi network
 5. Follow the captive portal instructions to select your desired WiFi connection
-6. Once connected, Badgy is ready to recieve new firmware! Go to http://*YOUR_IP_ADDRESS*:8888/update to upload your new firmware
+6. Once connected, Badgy is ready to receive new firmware! Go to http://*YOUR_IP_ADDRESS*:8888/update to upload your new firmware
 7. WiFi credentials are automatically saved onboard, your Badgy will automatically connect to your selected network the next time you perform an update
 
 Check out the examples folders for various Arduino code samples, we're constantly adding more!

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,13 +3,15 @@
 - Add ESP8266 Arduino Core using the Boards Manager https://github.com/esp8266/Arduino#installing-with-boards-manager
 - Install the following libraries for the various examples
     - Adafruit GFX library https://github.com/adafruit/Adafruit-GFX-Library
-    - GxEPD v2.x library https://github.com/ZinggJM/GxEPD
+    - GxEPD v3.x library https://github.com/ZinggJM/GxEPD
     - ArduinoJSON v5.x library https://github.com/bblanchon/ArduinoJson
     - WiFi Manager library https://github.com/tzapu/WiFiManager
+    - Time v1.5 https://github.com/michaelmargolis/arduino_time
+    - WebSockets https://github.com/Links2004/arduinoWebSockets
 - When compiling the sketch in the Arduino IDE, choose **Tools** > **Board** > **NodeMCU 1.0 (ESP-12E Module)**    
 
 ## Uploading Your Own Firmware
-1. In the Arduino IDE, go to *Sktech* -> *Export compiled Binary* to create your firmware binary `*.bin`
+1. In the Arduino IDE, go to *Sketch* -> *Export compiled Binary* to create your firmware binary `*.bin`
 2. Slide the power switch off (up), hold the center button and slide the power switch on (down) at the same time. Your Badgy should now be in OTA mode.
 3. Go to http://*BADGY_IP_ADDRESS*:8888/update to upload your new `*.bin` file
 4. Badgy will now restart with your new firmware

--- a/examples/hello/hello.ino
+++ b/examples/hello/hello.ino
@@ -1,8 +1,8 @@
   /* e-paper display lib */
 #include <GxEPD.h>
-#include <GxGDEH029A1/GxGDEH029A1.cpp>
-#include <GxIO/GxIO_SPI/GxIO_SPI.cpp>
-#include <GxIO/GxIO.cpp>
+#include <GxGDEH029A1/GxGDEH029A1.h>
+#include <GxIO/GxIO_SPI/GxIO_SPI.h>
+#include <GxIO/GxIO.h>
 /* include any other fonts you want to use https://github.com/adafruit/Adafruit-GFX-Library */
 #include <Fonts/FreeMonoBold9pt7b.h>
 #include <Fonts/FreeSansBoldOblique24pt7b.h>

--- a/examples/hourlyQuote/hourlyQuote.ino
+++ b/examples/hourlyQuote/hourlyQuote.ino
@@ -1,8 +1,8 @@
 /* e-paper display lib */
 #include <GxEPD.h>
-#include <GxGDEH029A1/GxGDEH029A1.cpp>
-#include <GxIO/GxIO_SPI/GxIO_SPI.cpp>
-#include <GxIO/GxIO.cpp>
+#include <GxGDEH029A1/GxGDEH029A1.h>
+#include <GxIO/GxIO_SPI/GxIO_SPI.h>
+#include <GxIO/GxIO.h>
 /* include any other fonts you want to use https://github.com/adafruit/Adafruit-GFX-Library */
 #include <Fonts/FreeMonoBold9pt7b.h>
 /* WiFi  libs*/

--- a/examples/spotify/spotify.ino
+++ b/examples/spotify/spotify.ino
@@ -1,8 +1,8 @@
  /* e-paper display lib */
 #include <GxEPD.h>
-#include <GxGDEH029A1/GxGDEH029A1.cpp>
-#include <GxIO/GxIO_SPI/GxIO_SPI.cpp>
-#include <GxIO/GxIO.cpp>
+#include <GxGDEH029A1/GxGDEH029A1.h>
+#include <GxIO/GxIO_SPI/GxIO_SPI.h>
+#include <GxIO/GxIO.h>
 /* include any other fonts you want to use https://github.com/adafruit/Adafruit-GFX-Library */
 #include <Fonts/FreeMonoBold9pt7b.h>
 #include <Fonts/FreeMonoBold12pt7b.h>

--- a/examples/weather/weather.ino
+++ b/examples/weather/weather.ino
@@ -1,8 +1,8 @@
 /* e-paper display lib */
 #include <GxEPD.h>
-#include <GxGDEH029A1/GxGDEH029A1.cpp>
-#include <GxIO/GxIO_SPI/GxIO_SPI.cpp>
-#include <GxIO/GxIO.cpp>
+#include <GxGDEH029A1/GxGDEH029A1.h>
+#include <GxIO/GxIO_SPI/GxIO_SPI.h>
+#include <GxIO/GxIO.h>
 /* include any other fonts you want to use https://github.com/adafruit/Adafruit-GFX-Library */
 #include <Fonts/FreeMonoBold9pt7b.h>
 #include <Fonts/FreeMonoBold18pt7b.h>

--- a/examples/websocketDraw/websocketDraw.ino
+++ b/examples/websocketDraw/websocketDraw.ino
@@ -1,8 +1,8 @@
 /* e-paper display lib */
 #include <GxEPD.h>
-#include <GxGDEH029A1/GxGDEH029A1.cpp>
-#include <GxIO/GxIO_SPI/GxIO_SPI.cpp>
-#include <GxIO/GxIO.cpp>
+#include <GxGDEH029A1/GxGDEH029A1.h>
+#include <GxIO/GxIO_SPI/GxIO_SPI.h>
+#include <GxIO/GxIO.h>
 /* include any other fonts you want to use https://github.com/adafruit/Adafruit-GFX-Library */
 #include <Fonts/FreeMonoBold9pt7b.h>
 /* WiFi  libs*/


### PR DESCRIPTION
This commit updates the example code to work with the latest version of GxEPD.

As shown in the [commit](https://github.com/ZinggJM/GxEPD/commit/e2869266d03eddef1d96eaab63b0a6f75eb7f91f), the GxGDEH029A1 files were not changed but the method for referencing / including them was. 

Sadly, this is a breaking change and the GxEPD 2.x library does not work with these changes in place. 

It's possible that there's no value in the update currently, beyond reducing confusion in new users (see: #18). I would argue that this is worth it, though, as it is far simpler to work with.

It also adds the undocumented library requirements on the example readme.md for Weather (Time) and WebSocketDraw (WebSockets), and corrects the spelling of 'sketch'.

I have tested that this fixes the compile errors in all of the provided examples, and that running the "hello" example with the latest version of GxEPD works correctly on my Badgy v2.

If this PR is merged, #23 should be rejected or merged in first (for continuity).